### PR TITLE
Add option to use color only if the output is to a TTY (terminal).

### DIFF
--- a/lib/prettystream.js
+++ b/lib/prettystream.js
@@ -23,7 +23,7 @@ var colors = {
 
 var defaultOptions = {
   mode: 'long', //short, long, dev
-  useColor: true
+  useColor: 'auto' // true, false, 'auto' (true if output is a TTY)
 };
 
 var levelFromName = {
@@ -55,7 +55,7 @@ Object.keys(levelFromName).forEach(function (name) {
 });
 
 function PrettyStream(opts){
-  var options = {};
+  var self = this, options = {};
 
   if (opts){
     Object.keys(opts).forEach(function(key){
@@ -72,6 +72,7 @@ function PrettyStream(opts){
 
   this.readable = true;
   this.writable = true;
+  this.isTTY = false;
 
   Stream.call(this);
 
@@ -80,7 +81,8 @@ function PrettyStream(opts){
       return '';
     }
 
-    if (!config.useColor){
+    if (config.useColor === false ||
+        (config.useColor === 'auto' && !self.isTTY)) {
       return str;
     }
 
@@ -425,6 +427,12 @@ PrettyStream.prototype.write = function write(data){
 PrettyStream.prototype.end = function end(){
   this.emit('end');
   return true;
+};
+
+// Track if we're piping into a TTY.
+PrettyStream.prototype.pipe = function(dest, options) {
+  this.isTTY = dest.isTTY;
+  return Stream.prototype.pipe.call(this, dest, options);
 };
 
 module.exports = PrettyStream;

--- a/test/prettystream.test.js
+++ b/test/prettystream.test.js
@@ -87,6 +87,28 @@ describe('A PrettyStream', function(){
     result.should.equal('[\u001b[37m2012-02-08T22:56:52.856Z\u001b[39m] \u001b[36m INFO\u001b[39m: myservice/123 on example.com: \u001b[36mMy message\u001b[39m\n');
   });
 
+  it('should pretty print colored log statments if output is a TTY', function(done){
+    var prettyStream = new PrettyStream({useColor: 'auto'});
+    var ts = new TestStream(function(result) {
+      result.should.equal('[\u001b[37m2012-02-08T22:56:52.856Z\u001b[39m] \u001b[36m INFO\u001b[39m: myservice/123 on example.com: \u001b[36mMy message\u001b[39m\n');
+    }, done);
+    ts.isTTY = true;
+    prettyStream.pipe(ts);
+    prettyStream.write(simpleRecord);
+    prettyStream.end();
+  });
+
+  it('should pretty print uncolored log statments if output is not a TTY', function(done){
+    var prettyStream = new PrettyStream({useColor: 'auto'});
+    var ts = new TestStream(function(result) {
+      result.should.equal('[2012-02-08T22:56:52.856Z]  INFO: myservice/123 on example.com: My message\n');
+    }, done);
+    ts.isTTY = false;
+    prettyStream.pipe(ts);
+    prettyStream.write(simpleRecord);
+    prettyStream.end();
+  });
+
   it('should pretty print simple request log statments', function(){
     var prettyStream = new PrettyStream({useColor: false});
     var result = prettyStream.formatRecord(simpleReqRecord);


### PR DESCRIPTION
The new `useColor='auto'` behavior is the new default.

Closes: #3
